### PR TITLE
Useless parentheses around expressions should be removed

### DIFF
--- a/notableLibrary/src/main/java/com/icechen1/notable/library/utils/NotificationAdapter.java
+++ b/notableLibrary/src/main/java/com/icechen1/notable/library/utils/NotificationAdapter.java
@@ -66,7 +66,7 @@ public class NotificationAdapter extends CursorRecyclerViewAdapter<RecyclerView.
         final ViewHolder vh = (ViewHolder) holder;
         final int position = cursor.getPosition();
         final int id = cursor.getInt(0);
-        final boolean dismissed = ((cursor.getInt(6)) == 1);
+        final boolean dismissed = (cursor.getInt(6) == 1);
         final long alarm = cursor.getLong(5);
 
         vh.mTitle.setText(cursor.getString(1));

--- a/notableLibrary/src/main/java/com/icechen1/notable/library/utils/NotificationDataSource.java
+++ b/notableLibrary/src/main/java/com/icechen1/notable/library/utils/NotificationDataSource.java
@@ -138,12 +138,12 @@ public class NotificationDataSource {
 		NotificationItem item = new NotificationItem();
 		try{
 			item.setID(cursor.getInt(0));
-			item.setTitle((cursor.getString(1)));
-			item.setLongText((cursor.getString(2)));
-			item.setTime((cursor.getLong(3)));
-			item.setIcon((cursor.getString(4)));
-			item.setReminderTime((cursor.getLong(5)));
-			item.setDismissed((cursor.getInt(6)) == 1);
+			item.setTitle(cursor.getString(1));
+			item.setLongText(cursor.getString(2));
+			item.setTime(cursor.getLong(3));
+			item.setIcon(cursor.getString(4));
+			item.setReminderTime(cursor.getLong(5));
+			item.setDismissed(cursor.getInt(6) == 1);
 		}catch(Exception e){
 			Log.e("NOTABLE","Error with database cursor!");
 			return null;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.