### PR TITLE
Remove app from recents after adding a reminder

### DIFF
--- a/notableLibrary/src/main/java/com/icechen1/notable/library/MainActivity.java
+++ b/notableLibrary/src/main/java/com/icechen1/notable/library/MainActivity.java
@@ -9,6 +9,7 @@ import android.content.pm.ResolveInfo;
 import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.speech.RecognizerIntent;
@@ -302,7 +303,11 @@ public class MainActivity
 
     public void addBtn(View v) {
         saveNotification();
-    	finish();
+        if(Build.VERSION.SDK_INT >= 21){
+            finishAndRemoveTask();
+        } else {
+            finish();
+        }
     }
 
     public void addAndStayBtn(View v) {


### PR DESCRIPTION
On Android >= Lollipop, call finishAndRemoveTask instead of finish
when creating a new reminder. This automatically removes the Notable
app from the recent apps list.

Fixes #15